### PR TITLE
Update teksten: vervang toekomende tijd naar tegenwoordige tijd

### DIFF
--- a/themes/nimma-codes/layouts/index.html
+++ b/themes/nimma-codes/layouts/index.html
@@ -7,8 +7,7 @@
             <p>
                 Er zijn volop softwarebedrijven, webbureaus en designagencies in Arnhem en Nijmegen. Ook zijn er een
                 hogeschool en universiteit met informatica-opleidingen waar mensen worden opgeleid tot programmeur of
-                developer. Toch is er nauwelijks een actieve developer community. Met Nimma Codes willen we daar
-                verandering in aanbrengen.
+                developer. Met Nimma Codes brengen we al deze mensen samen.
             </p>
         </div>
     </section>
@@ -21,15 +20,15 @@
                 primair op developers, zijn niet voor iedereen toegankelijk of te specialistisch.
             </p>
             <p>
-                Wij willen een actieve community creëren voor en door developers waar we met behulp van:</p>
+                Wij zijn een actieve community voor en door developers waar we met behulp van:</p>
             <ul>
-                <li>Praatjes</li>
-                <li><a target="_blank" rel="noopener noreferrer" href="https://medium.com/hackernoon/what-are-code-katas-and-why-should-we-care-2e3f1b7e111c">Coding dojo's of kata's</a></li>
-                <li>Samen bijdragen aan een open source project;</li>
-                <li>Puzzelen voor de Advent of Code;</li>
-                <li>Bedrijfsbezoeken;</li>
-                <li>En andere activiteiten elkaar willen leren kennen en elkaar willen helpen.</li>
-              </ul>  
+                <li>Praatjes;</li>
+                <li><a target="_blank" rel="noopener noreferrer" href="https://medium.com/hackernoon/what-are-code-katas-and-why-should-we-care-2e3f1b7e111c">coding dojo's of kata's</a>;</li>
+                <li>samen bijdragen aan een open source project;</li>
+                <li>puzzelen voor de Advent of Code;</li>
+                <li>bedrijfsbezoeken;</li>
+                <li>en andere activiteiten elkaar leren kennen en elkaar helpen.</li>
+            </ul>
         </div>
     </section>
 </div>
@@ -47,10 +46,10 @@
                 altijd al eens iets willen zien van een Rust of Go project, of ben je nieuwsgierig naar een functionele
                 taal
                 als F#, Haskell of Clojure, of wil je weten hoe PHP de afgelopen jaren geëvalueerd is. Met Nimma.codes
-                willen we voor al dit soort onderwerpen ruimte bieden.
+                bieden we voor al dit soort onderwerpen ruimte.
             </p>
             <p>
-                Met afwisselende activiteiten willen we het aantrekkelijk houden voor iedereen.
+                Met afwisselende activiteiten houden we het aantrekkelijk voor iedereen.
             </p>
         </div>
     </section>

--- a/themes/nimma-codes/layouts/index.html
+++ b/themes/nimma-codes/layouts/index.html
@@ -7,7 +7,7 @@
             <p>
                 Er zijn volop softwarebedrijven, webbureaus en designagencies in Arnhem en Nijmegen. Ook zijn er een
                 hogeschool en universiteit met informatica-opleidingen waar mensen worden opgeleid tot programmeur of
-                developer. Met Nimma Codes brengen we al deze mensen samen.
+                developer. Met Nimma.codes brengen we al deze mensen samen.
             </p>
         </div>
     </section>


### PR DESCRIPTION
Nu we een jaar onderweg zijn, lijkt het me toepasselijk om de websiteteksten ietsje te updaten.
Deze PR vervangt het gebruik van de z.g. "toekomende tijd" (bijv. "we willen een actieve community zijn"[^1]) naar de tegenwoordige tijd "we zijn een actieve community".

Daarnaast een kleine stijlverbetering: delen uit een opsomming die één zin vormen horen niet met een hoofdletter gespeld te worden. (zie bijv. [hier](https://onzetaal.nl/taalloket/opsommingen-leestekens-en-hoofdletters)).

[^1]: Technisch gezien geen toekomende tijd, dan zou het "we zullen een actieve community zijn" moeten zijn, maar je snapt wel wat ik bedoel.